### PR TITLE
overriding meta tags that use property="..." attributes rather than name="..."

### DIFF
--- a/lib/metamagic/helper_methods.rb
+++ b/lib/metamagic/helper_methods.rb
@@ -10,10 +10,10 @@ module Metamagic
     end
 
     def add_tag_if_not_existing(new_tag)
-      # add meta tag if it's not existing
-      unless meta_tags.find { |tag| tag[:name] && new_tag[:name] && tag[:name] == new_tag[:name] }
-        meta_tags << new_tag
-      end
+      # add meta tag if there's not an existing one with the same name or property attribute
+      return if meta_tags.find { |tag| tag[:name] && new_tag[:name] && tag[:name] == new_tag[:name] }
+      return if meta_tags.find { |tag| tag[:property] && new_tag[:property] && tag[:property] == new_tag[:property] }
+      meta_tags << new_tag
     end
 
     def add_meta_tags(options)

--- a/test/metamagic_test.rb
+++ b/test/metamagic_test.rb
@@ -30,4 +30,20 @@ class HelperMethodsTest < ActionView::TestCase
     assert_equal %{<title>Test Title</title>\n<meta content="Test description." name="description" />},
                  metamagic
   end
+
+  test "meta tags using property attribute rather than name" do
+    meta [property: "og:url", content: "http://test.url"]
+
+    assert_equal %{<meta content="http://test.url" property="og:url" />},
+                 metamagic
+  end
+
+  test "overriding default meta tags if the property attribute matches" do
+    meta [property: "og:url", content: "http://override.url"]
+
+    assert_equal %{<meta content="http://override.url" property="og:url" />},
+                 metamagic([property: "og:url", content: "http://default.url"])
+  end
+
+
 end


### PR DESCRIPTION
Hi, please find a suggested amendment whereby existing tags are searched for by "property" value in addition to "name". The use case is to allow (for example) a default og:image tag to be specified in the layout, and then overridden in the views.

Without this fix, the current behaviour is simply to output multiple og:image meta tags.

Thanks,
Kieran
