### PR TITLE
Allow colons in the default meta tag values

### DIFF
--- a/lib/metamagic/renderer.rb
+++ b/lib/metamagic/renderer.rb
@@ -104,7 +104,7 @@ module Metamagic
       Array(value).any? do |val|
         val.is_a?(Proc) ||
         val.is_a?(Symbol) ||
-        val =~ /:\w+/
+        val =~ /\A:\w+/
       end
     end
 

--- a/test/metamagic_test.rb
+++ b/test/metamagic_test.rb
@@ -20,6 +20,14 @@ class MetamagicTest < ActionView::TestCase
                  metamagic(title: "Default Title", description: "Default description", test: "Default test")
   end
 
+  test "default meta tags containing colons" do
+    meta title: "Test Title",
+         test: "Test tag"
+
+    assert_equal %{<title>Test Title</title>\n<meta content="Test tag" name="test" />\n<meta content="Default :description" name="description" />},
+                 metamagic(title: "Default:Title", description: "Default :description", test: "Default test")
+  end
+
   test "not adding existing meta tags" do
     meta title: "Test Title",
          description: "Test description."


### PR DESCRIPTION
Fixes #21
