### PR TITLE
Fix meta key name for twitter

### DIFF
--- a/lib/metamagic/tags/property_tag.rb
+++ b/lib/metamagic/tags/property_tag.rb
@@ -1,11 +1,19 @@
 module Metamagic
   class PropertyTag < Tag
     def to_html
-      interpolated_values.map { |value| tag(:meta, property: key, content: value) }.join("\n").html_safe.presence
+      interpolated_values.map { |value| tag(:meta, property_key => key, content_key => value) }.join("\n").html_safe.presence
     end
 
     def sort_order
       3
+    end
+
+    def property_key
+      :property
+    end
+
+    def content_key
+      :content
     end
   end
 end

--- a/lib/metamagic/tags/twitter_tag.rb
+++ b/lib/metamagic/tags/twitter_tag.rb
@@ -1,5 +1,9 @@
 module Metamagic
   class TwitterTag < PropertyTag
+    def property_key
+      :name
+    end
+
     def remove_prefix?
       false
     end

--- a/test/hash_from_xml.rb
+++ b/test/hash_from_xml.rb
@@ -1,0 +1,58 @@
+# USAGE: Hash.from_xml:(YOUR_XML_STRING)
+require 'nokogiri'
+# modified from http://stackoverflow.com/questions/1230741/convert-a-nokogiri-document-to-a-ruby-hash/1231297#1231297
+ 
+class Hash
+  class << self
+    def from_xml(xml_io) 
+      result = Loofah.fragment("<div>#{xml_io}</div>") # wrap
+      xml_node_to_hash(result.children.first)
+    end 
+ 
+    def xml_node_to_hash(node) 
+      # If we are at the root of the document, start the hash 
+      if node.element?
+        result_hash = {}
+        if node.attributes != {}
+          result_hash[:attributes] = {}
+          node.attributes.keys.each do |key|
+            result_hash[:attributes][node.attributes[key].name.to_sym] = prepare(node.attributes[key].value)
+          end
+        end
+        if node.children.size > 0
+          node.children.each do |child| 
+            result = xml_node_to_hash(child) 
+ 
+            if child.name == "text"
+              unless child.next_sibling || child.previous_sibling
+                return prepare(result)
+              end
+            elsif result_hash[child.name.to_sym]
+              if result_hash[child.name.to_sym].is_a?(Object::Array)
+                result_hash[child.name.to_sym] << prepare(result)
+              else
+                result_hash[child.name.to_sym] = [result_hash[child.name.to_sym]] << prepare(result)
+              end
+            else 
+              result_hash[child.name.to_sym] = prepare(result)
+            end
+          end
+ 
+          return result_hash 
+        else 
+          return result_hash
+        end 
+      else 
+        return prepare(node.content.to_s) 
+      end 
+    end          
+ 
+    def prepare(data)
+      (data.class == String && data.to_i.to_s == data) ? data.to_i : data
+    end
+  end
+  
+  def to_struct(struct_name)
+      Struct.new(struct_name,*keys).new(*values)
+  end
+end

--- a/test/hash_from_xml_test.rb
+++ b/test/hash_from_xml_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class HashFromXmlTest < ActionView::TestCase
+
+  test "from xml exmpty " do
+    xml = ''
+    assert_equal Hash.from_xml(xml),  {}
+  end
+
+  test "from xml 1 level " do
+    xml = '<meta name="description" content="description_text">'
+    assert_equal Hash.from_xml(xml),  { meta: { attributes: { name: "description", content: "description_text" } } }
+  end
+
+  test "from xml 2 level s" do
+    xml = '<div><span id="span1"></span><span id="span2"></span></div>'
+    assert_equal Hash.from_xml(xml),  { div: { span: [ { attributes: { id: "span1" } }, 
+                                                       { attributes: { id: "span2" } } ] } }
+  end
+
+end

--- a/test/link_tag_test.rb
+++ b/test/link_tag_test.rb
@@ -9,7 +9,7 @@ class LinkTagTest < ActionView::TestCase
     }
     rel publisher: "http://test.com/publisher.html"
 
-    assert_equal %{<link href="http://test.com/author.html" rel="author" />\n<link href="http://test.com/publisher.html" rel="publisher" />},
+    assert_equal_segment %{<link href="http://test.com/author.html" rel="author" />\n<link href="http://test.com/publisher.html" rel="publisher" />},
                  metamagic
   end
 end

--- a/test/meta_tag_test.rb
+++ b/test/meta_tag_test.rb
@@ -7,7 +7,7 @@ class MetaTagTest < ActionView::TestCase
     meta keywords: %w{one two three},
          description: "My description"
 
-    assert_equal %{<meta content="one, two, three" name="keywords" />\n<meta content="My description" name="description" />},
+    assert_equal_segment %{<meta content="one, two, three" name="keywords" />\n<meta content="My description" name="description" />},
                  metamagic
   end
 
@@ -15,7 +15,7 @@ class MetaTagTest < ActionView::TestCase
     keywords %w{one two three}
     description "My description"
 
-    assert_equal %{<meta content="one, two, three" name="keywords" />\n<meta content="My description" name="description" />},
+    assert_equal_segment %{<meta content="one, two, three" name="keywords" />\n<meta content="My description" name="description" />},
                  metamagic
   end
 
@@ -23,14 +23,14 @@ class MetaTagTest < ActionView::TestCase
     title "Test Title"
     description nil
 
-    assert_equal %{<title>Test Title</title>},
+    assert_equal_segment %{<title>Test Title</title>},
                  metamagic
   end
 
   test "array as meta value" do
     keywords %w{one two three}
 
-    assert_equal %{<meta content="one, two, three" name="keywords" />},
+    assert_equal_segment %{<meta content="one, two, three" name="keywords" />},
                  metamagic
   end
 
@@ -38,7 +38,7 @@ class MetaTagTest < ActionView::TestCase
     title "Test Title"
     keywords []
 
-    assert_equal %{<title>Test Title</title>},
+    assert_equal_segment %{<title>Test Title</title>},
                  metamagic
   end
 
@@ -46,7 +46,7 @@ class MetaTagTest < ActionView::TestCase
     title "Test Title"
     keywords ["one", nil, "two"]
 
-    assert_equal %{<title>Test Title</title>\n<meta content="one, two" name="keywords" />},
+    assert_equal_segment %{<title>Test Title</title>\n<meta content="one, two" name="keywords" />},
                  metamagic
   end
 
@@ -54,40 +54,40 @@ class MetaTagTest < ActionView::TestCase
     title "Test Title"
     keywords [nil]
 
-    assert_equal %{<title>Test Title</title>},
+    assert_equal_segment %{<title>Test Title</title>},
                  metamagic
   end
 
   test "keywords template" do
     keywords %w{added keywords}
 
-    assert_equal %{<meta content="added, keywords, default, from, layout" name="keywords" />},
+    assert_equal_segment %{<meta content="added, keywords, default, from, layout" name="keywords" />},
                  metamagic(keywords: [:keywords, "default", "from", "layout"])
   end
 
   test "keywords template with no keywords" do
-    assert_equal %{<meta content="default, from, layout" name="keywords" />},
+    assert_equal_segment %{<meta content="default, from, layout" name="keywords" />},
                  metamagic(keywords: [:keywords, "default", "from", "layout"])
   end
 
   test "unique values using templates" do
     keywords %w{added keywords}
 
-    assert_equal %{<meta content="added, keywords, default, from, layout" name="keywords" />},
+    assert_equal_segment %{<meta content="added, keywords, default, from, layout" name="keywords" />},
                  metamagic(keywords: [:keywords, "added", "default", "keywords", "from", "layout"])
   end
 
   test "html safe keywords" do
     keywords ["one", "two &rarr; test".html_safe, "three"]
 
-    assert_equal %{<meta content="one, two &rarr; test, three" name="keywords" />},
+    assert_equal_segment %{<meta content="one, two &rarr; test, three" name="keywords" />},
                  metamagic
   end
 
   test "html unsafe keywords" do
     keywords ["one", "two &rarr; test", "three"]
 
-    assert_equal %{<meta content="one, two &amp;rarr; test, three" name="keywords" />},
+    assert_equal_segment %{<meta content="one, two &amp;rarr; test, three" name="keywords" />},
                  metamagic
   end
 end

--- a/test/metamagic_test.rb
+++ b/test/metamagic_test.rb
@@ -8,7 +8,7 @@ class MetamagicTest < ActionView::TestCase
          description: "My description.",
          keywords: ["One", "Two", "Three"]
 
-    assert_equal %{<title>My Title</title>\n<meta content="My description." name="description" />\n<meta content="One, Two, Three" name="keywords" />},
+    assert_equal_segment %{<title>My Title</title>\n<meta content="My description." name="description" />\n<meta content="One, Two, Three" name="keywords" />},
                  metamagic
   end
 
@@ -16,7 +16,7 @@ class MetamagicTest < ActionView::TestCase
     meta title: "Test Title",
          test: "Test tag"
 
-    assert_equal %{<title>Test Title</title>\n<meta content="Test tag" name="test" />\n<meta content="Default description" name="description" />},
+    assert_equal_segment %{<title>Test Title</title>\n<meta content="Test tag" name="test" />\n<meta content="Default description" name="description" />},
                  metamagic(title: "Default Title", description: "Default description", test: "Default test")
   end
 
@@ -24,7 +24,7 @@ class MetamagicTest < ActionView::TestCase
     meta title: "Test Title",
          test: "Test tag"
 
-    assert_equal %{<title>Test Title</title>\n<meta content="Test tag" name="test" />\n<meta content="Default\n:something" name="description" />},
+    assert_equal_segment %{<title>Test Title</title>\n<meta content="Test tag" name="test" />\n<meta content="Default\n:something" name="description" />},
                  metamagic(title: "Default:Title", description: "Default\n:something", test: "Default test")
   end
 
@@ -35,7 +35,7 @@ class MetamagicTest < ActionView::TestCase
     meta title: "Second Title",
          description: "Second description."
 
-    assert_equal %{<title>Test Title</title>\n<meta content="Test description." name="description" />},
+    assert_equal_segment %{<title>Test Title</title>\n<meta content="Test description." name="description" />},
                  metamagic
   end
 
@@ -46,7 +46,7 @@ class MetamagicTest < ActionView::TestCase
     title "Second Title"
     description "Second description."
 
-    assert_equal %{<title>Test Title</title>\n<meta content="Test description." name="description" />},
+    assert_equal_segment %{<title>Test Title</title>\n<meta content="Test description." name="description" />},
                  metamagic
   end
 
@@ -55,20 +55,20 @@ class MetamagicTest < ActionView::TestCase
     description "My description"
     keywords %w{one two three}
 
-    assert_equal %{<title>My Title</title>\n<meta content="My description" name="description" />\n<meta content="one, two, three" name="keywords" />},
+    assert_equal_segment %{<title>My Title</title>\n<meta content="My description" name="description" />\n<meta content="one, two, three" name="keywords" />},
                  metamagic
   end
 
   test "shortcut helper returns value" do
-    assert_equal "My Title", title("My Title")
-    assert_equal "My Description", description("My Description")
-    assert_equal %w{one two three}, keywords(%w{one two three})
+    assert_equal_segment "My Title", title("My Title")
+    assert_equal_segment "My Description", description("My Description")
+    assert_equal_segment %w{one two three}, keywords(%w{one two three})
   end
 
   test "not adding templates from views" do
     title "This is a :nonexistent_key"
 
-    assert_equal %{<title>This is a :nonexistent_key</title>},
+    assert_equal_segment %{<title>This is a :nonexistent_key</title>},
                  metamagic
   end
 
@@ -79,7 +79,7 @@ class MetamagicTest < ActionView::TestCase
     keywords %w{one two three}
     title "My Title"
 
-    assert_equal %{<title>My Title</title>\n<meta content="one, two, three" name="keywords" />\n<meta content="My description." name="description" />\n<meta content="http://test.com/image.png" property="og:image" />\n<meta content="summary" property="twitter:card" />},
+    assert_equal_segment %{<title>My Title</title>\n<meta content="one, two, three" name="keywords" />\n<meta content="My description." name="description" />\n<meta content="http://test.com/image.png" property="og:image" />\n<meta content="summary" name="twitter:card" />},
                  metamagic
   end
 end

--- a/test/open_graph_test.rb
+++ b/test/open_graph_test.rb
@@ -12,7 +12,7 @@ class OpenGraphTest < ActionView::TestCase
          }
     og image: { type: "image/png" }
 
-    assert_equal %{<title>Test Title</title>\n<meta content="http://test.com/image.jpg" property="og:image:url" />\n<meta content="image/png" property="og:image:type" />},
+    assert_equal_segment %{<title>Test Title</title>\n<meta content="http://test.com/image.jpg" property="og:image:url" />\n<meta content="image/png" property="og:image:type" />},
                  metamagic
   end
 end

--- a/test/property_tag_test.rb
+++ b/test/property_tag_test.rb
@@ -7,14 +7,14 @@ class PropertyTagTest < ActionView::TestCase
     meta property: { one: "Property One", two: "Property Two", "og:image" => "http://test.com/image.png", nested: { a: "Nested A" } }
     property two: "Property Two second", three: "Property Three", nested: { a: "Nested A second", b: "Nested B" }
 
-    assert_equal %{<meta content="Property One" property="one" />\n<meta content="Property Two" property="two" />\n<meta content="http://test.com/image.png" property="og:image" />\n<meta content="Nested A" property="nested:a" />\n<meta content="Property Three" property="three" />\n<meta content="Nested B" property="nested:b" />},
+    assert_equal_segment %{<meta content="Property One" property="one" />\n<meta content="Property Two" property="two" />\n<meta content="http://test.com/image.png" property="og:image" />\n<meta content="Nested A" property="nested:a" />\n<meta content="Property Three" property="three" />\n<meta content="Nested B" property="nested:b" />},
                  metamagic
   end
 
   test "property array" do
     og image: ["one.jpg", "two.jpg"]
 
-    assert_equal %{<meta content="one.jpg" property="og:image" />\n<meta content="two.jpg" property="og:image" />},
+    assert_equal_segment %{<meta content="one.jpg" property="og:image" />\n<meta content="two.jpg" property="og:image" />},
                  metamagic
   end
 
@@ -22,7 +22,7 @@ class PropertyTagTest < ActionView::TestCase
     og title: "Test Title",
        image: nil
 
-    assert_equal %{<meta content="Test Title" property="og:title" />},
+    assert_equal_segment %{<meta content="Test Title" property="og:title" />},
                  metamagic
   end
 
@@ -30,7 +30,7 @@ class PropertyTagTest < ActionView::TestCase
     og title: "Test Title",
        image: [nil]
 
-    assert_equal %{<meta content="Test Title" property="og:title" />},
+    assert_equal_segment %{<meta content="Test Title" property="og:title" />},
                  metamagic
   end
 
@@ -38,7 +38,7 @@ class PropertyTagTest < ActionView::TestCase
     og title: "Test Title",
        image: ["one.jpg", nil, "two.jpg"]
 
-    assert_equal %{<meta content="Test Title" property="og:title" />\n<meta content="one.jpg" property="og:image" />\n<meta content="two.jpg" property="og:image" />},
+    assert_equal_segment %{<meta content="Test Title" property="og:title" />\n<meta content="one.jpg" property="og:image" />\n<meta content="two.jpg" property="og:image" />},
                  metamagic
   end
 
@@ -49,14 +49,14 @@ class PropertyTagTest < ActionView::TestCase
          tag: []
        }
 
-    assert_equal %{<meta content="http://test.com/image.png" property="og:image" />\n<meta content="Leif Davidsen" property="og:book:author" />\n<meta content="Anders Mogensen" property="og:book:author" />},
+    assert_equal_segment %{<meta content="http://test.com/image.png" property="og:image" />\n<meta content="Leif Davidsen" property="og:book:author" />\n<meta content="Anders Mogensen" property="og:book:author" />},
                  metamagic
   end
 
   test "property template" do
     og image: "http://test.com/image.jpg"
 
-    assert_equal %{<meta content="http://test.com/image.jpg" property="og:image" />\n<meta content="http://test.com/image2.jpg" property="og:image" />},
+    assert_equal_segment %{<meta content="http://test.com/image.jpg" property="og:image" />\n<meta content="http://test.com/image2.jpg" property="og:image" />},
                  metamagic(og: { image: [:og_image, "http://test.com/image2.jpg"] })
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,8 +3,15 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
+require 'hash_from_xml'
 
 Rails.backtrace_cleaner.remove_silencers!
+
+class ActionView::TestCase
+  def assert_equal_segment(first, second)
+    assert_equal Hash.from_xml(first),  Hash.from_xml(second)
+  end
+end
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].each { |f| require f }

--- a/test/title_tag_test.rb
+++ b/test/title_tag_test.rb
@@ -7,14 +7,14 @@ class TitleTagTest < ActionView::TestCase
   test "title tag" do
     meta title: "My Title"
 
-    assert_equal %{<title>My Title</title>},
+    assert_equal_segment %{<title>My Title</title>},
                  metamagic
   end
 
   test "shortcut helper" do
     title "My Title"
 
-    assert_equal %{<title>My Title</title>},
+    assert_equal_segment %{<title>My Title</title>},
                  metamagic
   end
 
@@ -22,38 +22,38 @@ class TitleTagTest < ActionView::TestCase
     title nil
     description "Test description"
 
-    assert_equal %{<meta content="Test description" name="description" />},
+    assert_equal_segment %{<meta content="Test description" name="description" />},
                  metamagic
   end
 
   test "title template" do
     title "Test Title"
 
-    assert_equal %{<title>Test Title - My Site</title>},
+    assert_equal_segment %{<title>Test Title - My Site</title>},
                  metamagic(site: "My Site", title: ":title - :site")
   end
 
   test "title template with no title set" do
-    assert_equal %{<title> - My Site</title>},
+    assert_equal_segment %{<title> - My Site</title>},
                  metamagic(site: "My Site", title: ":title - :site")
   end
 
   test "title separator" do
     title "Test Title"
 
-    assert_equal %{<title>Test Title - My Site</title>},
+    assert_equal_segment %{<title>Test Title - My Site</title>},
                  metamagic(site: "My Site", title: [:title, :site])
   end
 
   test "custom title separator" do
     title "Test Title"
 
-    assert_equal %{<title>Test Title | My Site</title>},
+    assert_equal_segment %{<title>Test Title | My Site</title>},
                  metamagic(site: "My Site", separator: " | ", title: [:title, :site])
   end
 
   test "title separator with no title" do
-    assert_equal %{<title>My Site</title>},
+    assert_equal_segment %{<title>My Site</title>},
                  metamagic(site: "My Site", title: [:title, :site])
   end
 
@@ -68,63 +68,63 @@ class TitleTagTest < ActionView::TestCase
   test "title template proc" do
     title "Test Title"
 
-    assert_equal %{<title>Site: My Site - Title: Test Title</title>},
+    assert_equal_segment %{<title>Site: My Site - Title: Test Title</title>},
                  metamagic(site: "My Site", title: -> { "Site: #{site} - Title: #{title}" })
   end
 
   test "title template from view helper" do
     title "Test Title"
 
-    assert_equal %{<title>From view helper: Test Title - My Site</title>},
+    assert_equal_segment %{<title>From view helper: Test Title - My Site</title>},
                  metamagic(site: "My Site", title: -> { meta_title_for(site, title) })
   end
 
   test "html safe titles" do
     title "My Site &rarr; Test".html_safe
 
-    assert_equal %{<title>My Site &rarr; Test</title>},
+    assert_equal_segment %{<title>My Site &rarr; Test</title>},
                  metamagic
   end
 
   test "html safe titles in template" do
     title "Test &rarr; Test".html_safe
 
-    assert_equal %{<title>Test &rarr; Test - My Site</title>},
+    assert_equal_segment %{<title>Test &rarr; Test - My Site</title>},
                  metamagic(title: ":title - :site", site: "My Site")
   end
 
   test "html unsafe titles" do
     title "My Site &rarr; Test"
 
-    assert_equal %{<title>My Site &amp;rarr; Test</title>},
+    assert_equal_segment %{<title>My Site &amp;rarr; Test</title>},
                  metamagic
   end
 
   test "html unsafe titles in template" do
     title "Test &rarr; Test"
 
-    assert_equal %{<title>Test &amp;rarr; Test - My Site</title>},
+    assert_equal_segment %{<title>Test &amp;rarr; Test - My Site</title>},
                  metamagic(title: ":title - :site", site: "My Site")
   end
 
   test "html safe title template" do
     title "Test Title"
 
-    assert_equal %{<title>Test Title &rarr; My Site</title>},
+    assert_equal_segment %{<title>Test Title &rarr; My Site</title>},
                  metamagic(title: ":title &rarr; :site".html_safe, site: "My Site")
   end
 
   test "html unsafe title template" do
     title "Test Title"
 
-    assert_equal %{<title>Test Title &amp;rarr; My Site</title>},
+    assert_equal_segment %{<title>Test Title &amp;rarr; My Site</title>},
                  metamagic(title: ":title &rarr; :site", site: "My Site")
   end
 
   test "deprecated title_template option" do
     title "Test Title"
 
-    assert_equal %{<title>Test Title - My Site</title>},
+    assert_equal_segment %{<title>Test Title - My Site</title>},
                  metamagic(site: "My Site", title_template: ":title - :site")
   end
 end

--- a/test/twitter_tag_test.rb
+++ b/test/twitter_tag_test.rb
@@ -11,7 +11,7 @@ class TwitterTest < ActionView::TestCase
     twitter site: "@flickr"
 
 
-    assert_equal %{<title>Test Title</title>\n<meta content="summary" property="twitter:card" />\n<meta content="@flickr" property="twitter:site" />},
+    assert_equal_segment %{<title>Test Title</title>\n<meta content="summary" name="twitter:card" />\n<meta content="@flickr" name="twitter:site" />},
                  metamagic
   end
 end


### PR DESCRIPTION
Accordingly to 'https://dev.twitter.com/cards/types/summary' we should use 'name' key instead of 'property'